### PR TITLE
Add IgnoreSignals to Options

### DIFF
--- a/gonnel.go
+++ b/gonnel.go
@@ -197,12 +197,14 @@ func (c *Client) StartServer(isReady chan bool) {
 		log.Fatal(err)
 	}
 
-	signalChan := make(chan os.Signal, 1)
-	signal.Notify(
-		signalChan, syscall.SIGHUP,
-		syscall.SIGINT, syscall.SIGTERM,
-		syscall.SIGQUIT)
-	go c.handleSignalInput(signalChan)
+	if !c.Options.IgnoreSignals {
+		signalChan := make(chan os.Signal, 1)
+		signal.Notify(
+			signalChan, syscall.SIGHUP,
+			syscall.SIGINT, syscall.SIGTERM,
+			syscall.SIGQUIT)
+		go c.handleSignalInput(signalChan)
+	}
 
 	checkNGReady, err := regexp.Compile(ngReady)
 	if err != nil {

--- a/gonnel.go
+++ b/gonnel.go
@@ -79,12 +79,13 @@ func (p Protocol) String() string { return protocols[p] }
 // Not all of this option necessary, if AuthToken provided then
 // binary will run auth token first.
 type Options struct {
-	SubDomain  string // Sub domain config if you're using premium plan
-	AuthToken  string // Auth token to authenticate client
-	Region     string // Region that will tunneling from
-	ConfigPath string // Path config to store auth token or specific WebUI port
-	BinaryPath string // Binary file that will be running
-	LogBinary  bool   // You can watch binary log or not
+	SubDomain     string // Sub domain config if you're using premium plan
+	AuthToken     string // Auth token to authenticate client
+	Region        string // Region that will tunneling from
+	ConfigPath    string // Path config to store auth token or specific WebUI port
+	BinaryPath    string // Binary file that will be running
+	LogBinary     bool   // You can watch binary log or not
+	IgnoreSignals bool   // Run child processes in a separate process group to ignore signals
 }
 
 // Client that provides all option and tunnel
@@ -149,6 +150,12 @@ func (o *Options) AuthTokenCommand() error {
 	}
 
 	cmd := exec.Command(o.BinaryPath, commands...)
+	if o.IgnoreSignals {
+		cmd.SysProcAttr = &syscall.SysProcAttr{
+			Setpgid: true,
+			Pgid:    0,
+		}
+	}
 	var outBuffer, errBuffer bytes.Buffer
 	cmd.Stdout = &outBuffer
 	cmd.Stderr = &errBuffer
@@ -174,6 +181,12 @@ func (c *Client) StartServer(isReady chan bool) {
 
 	commands := c.Options.generateCommands()
 	cmd := exec.Command(c.Options.BinaryPath, commands...)
+	if c.Options.IgnoreSignals {
+		cmd.SysProcAttr = &syscall.SysProcAttr{
+			Setpgid: true,
+			Pgid:    0,
+		}
+	}
 	c.runningCmd = cmd
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {


### PR DESCRIPTION
While working with `gonnel`, I noticed that it intercepts the signals sent to my main process and terminates the application. This prevented me from doing some pre-termination work.

This pull request adds `IgnoreSignals` (defaults to `false` for backward compat). When set to `true`, two things happen:

1. `gonnel` will not attempt to handle any OS signals anymore.
2. `gonnel` will spawn child processes in a **separate process group** to prevent them from catching OS signals that are sent to the parent process (which is the Go app that uses `gonnel`.) See https://stackoverflow.com/a/35435038/3455614 for more details.

Thanks!